### PR TITLE
remove defuddle link and fix navigator property handling in new version of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Command line interface for [Defuddle](https://github.com/kepano/defuddle). Extra
 ## Installation
 
 ```bash
-npm install -g @defuddle/cli
+npm install -g defuddle/cli
 ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,24 +25,6 @@
         "typescript": "^5.3.3"
       }
     },
-    "../defuddle": {
-      "version": "0.3.4",
-      "license": "MIT",
-      "devDependencies": {
-        "@types/node": "^20.0.0",
-        "concurrently": "^8.2.2",
-        "terser-webpack-plugin": "^5.3.14",
-        "ts-loader": "^9.5.1",
-        "typescript": "^5.3.3",
-        "undici-types": "^5.0.0",
-        "webpack": "^5.90.3",
-        "webpack-cli": "^5.1.4"
-      },
-      "optionalDependencies": {
-        "mathml-to-latex": "^1.4.3",
-        "temml": "^0.11.2"
-      }
-    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.1.1.tgz",
@@ -197,6 +179,15 @@
       "integrity": "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==",
       "dev": true
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -303,8 +294,13 @@
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
     },
     "node_modules/defuddle": {
-      "resolved": "../defuddle",
-      "link": true
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/defuddle/-/defuddle-0.3.4.tgz",
+      "integrity": "sha512-ogAVO3rOkpv72eYX6yNgehk/O6sSApctJ0z7L3/xkUYjYhD7t4T1RhOmfisTx5kDEZ/M/9Mynjps5TEuUtFSWg==",
+      "optionalDependencies": {
+        "mathml-to-latex": "^1.4.3",
+        "temml": "^0.11.2"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -586,6 +582,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mathml-to-latex": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/mathml-to-latex/-/mathml-to-latex-1.4.3.tgz",
+      "integrity": "sha512-RfMRrpIBEk/BweXKZx0Mb3u5nA6/vKASYeVnclAed6pEhnfaCi1jfDqXYBEbzRsS+ORd1jB88Easa1Ov7majKQ==",
+      "optional": true,
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.10"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -680,6 +685,15 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "node_modules/temml": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/temml/-/temml-0.11.2.tgz",
+      "integrity": "sha512-7YkDcDYE5UXV6yOGYgcT2A0J+IeXye2gXg77eH8WxLOcVssGMxPSxkh6GkyZ5owLM4C3u/d5oG/2gZrlQ+mAew==",
+      "optional": true,
+      "engines": {
+        "node": ">=18.13.0"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "4.1.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -777,7 +777,16 @@ const window = dom.window;
 (globalThis as any).Range = window.Range;
 (globalThis as any).DOMParser = window.DOMParser;
 (globalThis as any).XMLSerializer = window.XMLSerializer;
-(globalThis as any).navigator = window.navigator;
+
+// Handle navigator property
+if (!globalThis.navigator || Object.getOwnPropertyDescriptor(globalThis, 'navigator')?.configurable) {
+	Object.defineProperty(globalThis, 'navigator', {
+		value: window.navigator,
+		writable: false,
+		configurable: true
+	});
+}
+
 (globalThis as any).HTMLElement = window.HTMLElement;
 
 // Define DOMSettableTokenList


### PR DESCRIPTION
1. use latest defuddle without link
2. fix a node version compatibility issues:
In Node.js > 20, `globalThis.navigator` is defined as a getter-only property, which causes the error:
`TypeError: Cannot set property navigator of #<Object> which has only a getter`