### PR TITLE
Clean up JSDOM + exit process on success

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -870,6 +870,12 @@ program
 					} else {
 						console.log(output);
 					}
+
+					// Clean up JSDOM resources
+					contentDom.window.close();
+					dom.window.close();
+					
+					process.exit(0);
 				} catch (error) {
 					console.error(chalk.red('Error during parsing:'), error);
 					process.exit(1);


### PR DESCRIPTION
Fixes #5 

My local test of these changes:

Command:

```
npm run build
npm start parse https://www.henrikkarlsson.xyz/p/why-we-ended-up-homeschooling -- -o test.md -m
```

Output:

```
> defuddle-cli@0.1.2 start
> node dist/index.js parse https://www.henrikkarlsson.xyz/p/why-we-ended-up-homeschooling -o test.md -m

Output written to test.md
```